### PR TITLE
Task: T0045 - Additions in hr_timesheet_sheet.sheet

### DIFF
--- a/magnus_timesheet/__init__.py
+++ b/magnus_timesheet/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from . import wizard

--- a/magnus_timesheet/__manifest__.py
+++ b/magnus_timesheet/__manifest__.py
@@ -33,7 +33,7 @@ The extended date range validation process is:
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['base', 'hr_timesheet', 'hr_timesheet_sheet', 'date_range'],
+    'depends': ['base', 'hr_timesheet', 'hr_timesheet_sheet', 'date_range', 'magnus_invoicing'],
 
     # always loaded
     'data': [

--- a/magnus_timesheet/models/hr_timesheet_sheet.py
+++ b/magnus_timesheet/models/hr_timesheet_sheet.py
@@ -25,7 +25,11 @@ class HrTimesheetSheet(models.Model):
             if week.id not in logged_weeks:
                 rec.update({'week_id': week.id})
             else:
-                rec.update({'week_id': False})
+                upcoming_week = self.env['date.range'].search([('id', 'not in', logged_weeks), ('type_id','in',['week','Week','WEEK']), ('date_start', '>', dt-timedelta(days=dt.weekday()))], order='date_start', limit=1)
+                if upcoming_week:
+                    rec.update({'week_id': upcoming_week.id})
+                else:
+                    rec.update({'week_id': False})
         else:
             if self._uid == SUPERUSER_ID:
                 raise UserError(_('Please generate Date Ranges.\n Menu: Settings > Technical > Date Ranges > Generate Date Ranges.'))

--- a/magnus_timesheet/views/hr_timesheet_views.xml
+++ b/magnus_timesheet/views/hr_timesheet_views.xml
@@ -9,7 +9,7 @@
       <field name="arch" type="xml">
         <xpath expr="//group[1]/group[1]" position="before">
           <group>
-            <field name="week_id" attrs="{'readonly': [('state', 'not in', ['new'])]}" options="{'no_create': True}"/>
+            <field name="week_id" attrs="{'readonly': [('state', 'not in', ['new'])]}" options="{'no_create': True, 'limit': 0}"/>
           </group>
         </xpath>
         <xpath expr="//notebook/page[1]/widget[1]" position="before">
@@ -42,6 +42,9 @@
         <field name="name" position="attributes">
           <attribute name="invisible">1</attribute>
         </field>
+        <field name="project_id" position="before">
+          <field name="week_id" string="Timesheet Week"/>
+        </field>
       </field>
     </record>
 
@@ -54,6 +57,11 @@
           <field name="week_id"/>
         </field>
       </field>
+    </record>
+
+    <!--My Timesheets action inherited-->
+    <record id="hr_timesheet_sheet.act_hr_timesheet_sheet_my_timesheets" model="ir.actions.act_window">
+      <field name="context">{'readonly_by_pass': True}</field>
     </record>
 
   </data>

--- a/magnus_timesheet/wizard/__init__.py
+++ b/magnus_timesheet/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import hr_timesheet_current

--- a/magnus_timesheet/wizard/hr_timesheet_current.py
+++ b/magnus_timesheet/wizard/hr_timesheet_current.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+
+class HrTimesheetCurrentOpen(models.TransientModel):
+    _inherit = 'hr.timesheet.current.open'
+
+    @api.model
+    def open_timesheet(self):
+        result = super(HrTimesheetCurrentOpen, self).open_timesheet()
+        result['context'] = "{'readonly_by_pass': True}"
+        return result


### PR DESCRIPTION
Task link: https://bo-test.magnus.nl/web#id=58&view_type=form&model=project.task&action=143
Module: magnus_timesheet.
Note: This commit implements the following points
2. in treeview account.analytic.line.tree.hr_timesheet we want to make the field Timesheet Week (week_id) visible.
11.2 Please limit the number of weeks shown in the preview of the week_id selection field
11.3 By default set current week in the field week_id, when the current week is already logged load the upcoming empty unlogged week
Fixed the issue of onchange with readonly field which was causing the problem of loading the wrong timesheet period.