### PR TITLE
Task: T0079 - Staffing & Planning (Feedback 17th of January 2019)

### DIFF
--- a/magnus_timesheet/models/analytic.py
+++ b/magnus_timesheet/models/analytic.py
@@ -40,6 +40,11 @@ class AccountAnalyticLine(models.Model):
                 WHERE id = %s""",
                 (res.select_week_id.id, res.id),
             )
+
+        if self.env.context.get('default_planned', True) and res.project_id != False:
+            self.env.cr.execute(
+                """UPDATE account_analytic_line SET planned = TRUE WHERE id = %s""" %(res.id)
+            )
         return res
 
     @api.multi
@@ -51,6 +56,11 @@ class AccountAnalyticLine(models.Model):
                     """UPDATE account_analytic_line SET week_id = %s
                     WHERE id = %s""",
                     (obj.select_week_id.id, obj.id),
+                )
+
+            if self.env.context.get('default_planned', True) and obj.project_id != False:
+                self.env.cr.execute(
+                    """UPDATE account_analytic_line SET planned = TRUE WHERE id = %s""" %(obj.id)
                 )
         return res
 


### PR DESCRIPTION
Module: magnus_timesheet.
Notes: To fix the access error (problem 1), updated record rule domain to ['|',('user_id','=',user.id),('user_id','=',False)] manually in the UI itself. 
Please find the record rule name (Analytic Lines in Timesheets) and id (142) and the old domain (['|',('sheet_id.validator_user_ids', 'in', [user.id]),('sheet_id.employee_id.user_id','=',user.id)]).