### PR TITLE
FIX: _get_related_employees() with res.user() (i.e an empty set)

### DIFF
--- a/magnus_timesheet/models/analytic.py
+++ b/magnus_timesheet/models/analytic.py
@@ -294,7 +294,7 @@ class AccountAnalyticLine(models.Model):
         user_id = vals.get('user_id', False)
 
         #some cases product id is missing
-        if not vals.get('product_id', False):
+        if not vals.get('product_id', False) and user_id:
             product_id = self.get_task_user_product(task_id, user_id) or False
             if not product_id:
                 user = self.env.user.browse(user_id)
@@ -322,7 +322,7 @@ class AccountAnalyticLine(models.Model):
             user_id = vals.get('user_id', aal.user_id and aal.user_id.id)
 
             # some cases product id is missing
-            if not vals.get('product_id', aal.product_id):
+            if not vals.get('product_id', aal.product_id) and user_id:
                 product_id = aal.get_task_user_product(task_id, user_id) or False
                 if not product_id:
                     user = self.env.user.browse(user_id)


### PR DESCRIPTION
method _get_related_employees() has self.ensure_one throwing error due to res.user is an empty set, that could happens when user doesn't have privilege to access other user, so i added sudo() for browsing