### PR TITLE
Dev sify

### DIFF
--- a/magnus_timesheet/models/account_invoice.py
+++ b/magnus_timesheet/models/account_invoice.py
@@ -41,19 +41,19 @@ class AccountInvoice(models.Model):
     def compute_target_invoice_amount(self):
         try:
             if self.amount_untaxed != self.target_invoice_amount:
+                self.reset_target_invoice_amount()
                 factor = self.target_invoice_amount / self.amount_untaxed
                 discount = (1.0 - factor) * 100
                 for line in self.invoice_line_ids:
                     line.discount = discount
+                taxes_grouped = self.get_taxes_values()
+                tax_lines = self.tax_line_ids.filtered('manual')
+                for tax in taxes_grouped.values():
+                    tax_lines += tax_lines.new(tax)
+                self.tax_line_ids = tax_lines
         except ZeroDivisionError:
             raise UserError(_('You cannot set a target amount if the invoice line amount is 0'))
 
-    # onchange to trigger  reset_target_invoice_amount for calculating taxes correctly
-
-    @api.onchange('invoice_line_ids')
-    def _onchange_invoice_line_ids(self):
-        self.reset_target_invoice_amount()
-        return super(AccountInvoice, self)._onchange_invoice_line_ids()
 
     def reset_target_invoice_amount(self):
         for line in self.invoice_line_ids:


### PR DESCRIPTION
1. Method compute_target_invoice_amount throws an error when a line amount is not filled in. This is because it’s trying to divide by 0. If this is the case, a validation message should be displayed stating ‘you cannot set a target amount if the invoice line amount is 0’
2. Method compute_target_invoice_amount does not recalculate the proper tax. If a user clicks the button to change the invoice line amounts, the tax will be wrong. This should be fixed.