### PR TITLE
T0457-Partner approval of expenses

### DIFF
--- a/magnus_expense/__manifest__.py
+++ b/magnus_expense/__manifest__.py
@@ -26,7 +26,8 @@
         # 'security/ir.model.access.csv',
         'views/hr_expense_views.xml',
         'views/res_company_view.xml',
-#        'views/account_views.xml',
+        'security/security.xml'
+        # 'views/account_views.xml',
     ],
     # only loaded in demonstration mode
     'demo': [

--- a/magnus_expense/security/security.xml
+++ b/magnus_expense/security/security.xml
@@ -1,0 +1,9 @@
+<odoo>
+    <data>
+      <record id="group_hr_expense_partner" model="res.groups">
+      <field name="name">Partner</field>
+      <field name="implied_ids" eval="[(4, ref('hr_expense.group_hr_expense_manager'))]"/>
+      <field name="category_id" ref="base.module_category_hr_expense"/>
+    </record>
+    </data>
+</odoo>

--- a/magnus_expense/views/hr_expense_views.xml
+++ b/magnus_expense/views/hr_expense_views.xml
@@ -71,27 +71,49 @@
             <field name="act_window_id" ref="hr_expense.action_hr_expense_refused_expenses"/>
         </record>
 
-        <record id="magnus_expense_hr_expense_sheet_form2" model="ir.ui.view">
-            <field name="name">hr.expense.form.magnus.expense2</field>
+    <record id="magnus_expense_hr_expense_sheet_form2" model="ir.ui.view">
+        <field name="name">hr.expense.form.magnus.expense2</field>
+        <field name="model">hr.expense.sheet</field>
+        <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='expense_line_ids']" position="attributes">
+                <attribute name="readonly">False</attribute>
+            </xpath>
+            <xpath expr="//field[@name='expense_line_ids']/tree/field[@name='name']" position="after">
+                <field name="account_id"/>
+            </xpath>
+            <xpath expr="//button[@name='action_sheet_move_create']" position="replace">
+                <button name="action_sheet_move_create" states="approve,approve_partner,revise"
+                        string="Post Journal Entries" type="object" groups="account.group_account_user"
+                        class="oe_highlight o_expense_sheet_post"/>
+            </xpath>
+            <xpath expr="//button[@name='%(hr_expense.hr_expense_refuse_wizard_action)d']" position="after">
+                <button name="%(hr_expense.hr_expense_refuse_wizard_action)d" states="approve_partner" string="Refuse"
+                        type="action" groups="account.group_account_user"/>
+            </xpath>
+            <xpath expr="//header/field[@name='state']" position="replace">
+                <field name="state" widget="statusbar"
+                       statusbar_visible="draft,submit,approve,approve_partner,post,done"/>
+            </xpath>
+            <xpath expr="//button[@name='action_sheet_move_create']" position="after">
+                <button name="revise_expense" type="object" string="Revise Expense" class="oe_highlight"
+                        states="approve,approve_partner" groups="hr_expense.group_hr_expense_manager"/>
+                <button name="expense_revised" type="object" string="Re-Submit" class="oe_highlight" states="revise"
+                        groups="hr_expense.group_hr_expense_manager"/>
+            </xpath>
+            <xpath expr="//field[@name='expense_line_ids']" position="attributes">
+                <attribute name="domain">[('employee_id', '=', employee_id)]</attribute>
+            </xpath>
+        </field>
+<!--    Adding the approve_partner to search filter to post-->
+    </record>
+        <record id="magnus_expense_hr_expense_sheet_filter" model="ir.ui.view">
+            <field name="name">hr.expense.filter.magnus.expense2</field>
             <field name="model">hr.expense.sheet</field>
-            <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form"/>
+            <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_filter"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='expense_line_ids']" position="attributes">
-                    <attribute name="readonly">False</attribute>
-                </xpath>
-                <xpath expr="//field[@name='expense_line_ids']/tree/field[@name='name']" position="after">
-                    <field name="account_id"/>
-                </xpath>
-                <xpath expr="//button[@name='action_sheet_move_create']" position="replace">
-                    <button name="action_sheet_move_create" states="approve,revise" string="Post Journal Entries" type="object" groups="account.group_account_user" class="oe_highlight o_expense_sheet_post"/>
-                </xpath>
-
-                <xpath expr="//button[@name='action_sheet_move_create']" position="after">
-                    <button name="revise_expense" type="object" string="Revise Expense" class="oe_highlight" states="approve" groups="hr_expense.group_hr_expense_manager"/>
-                    <button name="expense_revised" type="object" string="Re-Submit" class="oe_highlight" states="revise" groups="hr_expense.group_hr_expense_manager"/>
-                </xpath>
-                <xpath expr="//field[@name='expense_line_ids']" position="attributes">
-                    <attribute name="domain">[('employee_id', '=', employee_id)]</attribute>
+                    <xpath expr="//search/filter[@name='to_post']" position="replace">
+                    <filter domain="['|',('state', '=', 'approve'),('state', '=', 'approve_partner')]" string="To Post" name="to_post" help="Approved Expenses"/>
                 </xpath>
             </field>
         </record>
@@ -127,6 +149,24 @@
             </field>
         </record>
 
+    <!-- adding new menu action Partner Approval-->
+
+    <record id="action_hr_expense_sheet_all_to_approve_partner" model="ir.actions.act_window">
+        <field name="name">Expense Reports to Approve by Partner</field>
+        <field name="res_model">hr.expense.sheet</field>
+        <field name="view_mode">tree,kanban,form,pivot,graph</field>
+        <field name="search_view_id" ref="hr_expense.view_hr_expense_sheet_filter"/>
+        <field name="domain">[('employee_id.parent_id.user_id', '=', uid)]</field>
+        <field name="context">{'search_default_submitted': 1}</field>
+        <field name="help" type="html">
+            <p class="oe_view_nocontent_create">
+                Click here to create a new expense report.
+            </p><p>
+            Once you have created your expense, submit it to your manager who will validate it.
+        </p>
+        </field>
+    </record>
+
     <record id="hr_expense.action_hr_expense_sheet_my_all" model="ir.actions.act_window">
         <field name="context">{'readonly_by_pass': True}</field>
     </record>
@@ -146,5 +186,13 @@
     <record id="hr_expense.action_hr_expense_sheet_all_all" model="ir.actions.act_window">
         <field name="context">{'readonly_by_pass': True}</field>
     </record>
+
+    <record model="ir.ui.menu" id="hr_expense.menu_hr_expense_sheet_all_to_approve">
+        <field name='name'>Manager Approval</field>
+    </record>
+
+    <menuitem id="menu_hr_expense_sheet_all_to_approve_partner" name="Partner Approval" sequence="1"
+              parent="hr_expense.menu_hr_expense_to_approve"
+              action="action_hr_expense_sheet_all_to_approve_partner" groups="magnus_expense.group_hr_expense_partner"/>
 
 </odoo>


### PR DESCRIPTION
1. new group called “Expenses / Partner” 
2.Rename the current status “Approved” to “Approved By Manager”
3.Introduce a new status “Approved By Partner” in between “Approved” and "Posted"
4. new menu under “To Approve” called “Partner Approval” and rename the existing menu “Expense Reports To Approve” to “Manager Approval”. 
5.new menu “Partner Approval” should only be visible for the new user group “Expenses / Partner”. The new menu should call the same form as the existing “Expense Reports To Approve”. 
6.The list of expenses that are to be approved by a partner should only consist of the expenses of employees that are member of departments that are childs (any level) of the respective partner's department.