### PR TITLE
Added more Features to magnus_equipment

### DIFF
--- a/magnus_equipment/models/maintenance.py
+++ b/magnus_equipment/models/maintenance.py
@@ -9,5 +9,17 @@ from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMA
 class MaintenanceEquipment(models.Model):
     _inherit = 'maintenance.equipment'
 
-    start_date = fields.Date(string="Start Date")
-    end_date = fields.Date(string="End Date")
+    start_date = fields.Date(string="Purchased on")
+    end_date = fields.Date(string="Replaced on")
+    is_being_repaired=fields.Boolean(string="The device currently is being repaired")
+    imei_number=fields.Char("IMEI Number")
+    owner_history=fields.One2many('equipment.user','maintenance_equipment_id',string='Owner History')
+
+  
+class MaintanceEquipmentUser(models.Model):
+
+    _name = 'equipment.user'
+
+    maintenance_equipment_id=fields.Many2one('maintenance.equipment',string="Equipment")
+    employee_name=fields.Many2one('hr.employee',string="Employee Name")
+    from_date=fields.Date(string="From Date")

--- a/magnus_equipment/views/maintenance_equipment_view.xml
+++ b/magnus_equipment/views/maintenance_equipment_view.xml
@@ -9,6 +9,42 @@
                     <field name="start_date"/>
                     <field name="end_date"/>
                 </xpath>
+                <xpath expr="//notebook/page[1]" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//notebook/page[3]/group/group/label[1]" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//notebook/page[3]/group/group/label[2]" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//notebook/page[3]/group/group/div[1]" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                 <xpath expr="//notebook/page[3]/group/group/div[2]" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//notebook/page[3]/group/group" position="inside">
+                  <field name="is_being_repaired"/>
+                </xpath>
+                <xpath expr="//notebook/page[2]/group/group/field[@name='partner_ref']" position="attributes">
+                  <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//notebook/page[2]/group/group/field[@name='partner_ref']" position="after">
+                  <field name="imei_number"/>
+                </xpath>
+                <xpath expr="//notebook/page[3]" position="after">
+                    <page string="Owner History">
+                        <field name="owner_history" widget="one2many_list">
+                                <tree string="Owner History List">
+                                    <field name="employee_name"/>
+                                    <field name="from_date"/>
+                                </tree>
+                        </field>
+                    </page>
+
+                </xpath>
+
             </field>
         </record>
   </data>


### PR DESCRIPTION
• Hide the "Description" tab
• Hide the fields period and maintenance_duration in the maintenance tab, and introduce a boolean called is_being_repaired which should be displayed as "The device currently is being repaired"
• The field start_date should be displayed as "Purchased on"
• The field end_date should be displayed as "Replaced on"
• Maintenance_team_id and technician_used_id
• In product information, you should hide the field partner_ref, and add a new field called imei_number, displayed as "IMEI Number".
.Add owner history table