### PR TITLE
[UPD] disable recomputation on timesheets

### DIFF
--- a/magnus_timesheet/__manifest__.py
+++ b/magnus_timesheet/__manifest__.py
@@ -54,7 +54,8 @@ thereof""",
                 'hr_timesheet_sheet_validators',
                 # 'connector_jira',
                 'web_domain_field',
-                'invoice_line_revenue_distribution_operating_unit'
+                'invoice_line_revenue_distribution_operating_unit',
+                'queue_job',
                 ],
 
     # always loaded

--- a/magnus_timesheet/models/analytic.py
+++ b/magnus_timesheet/models/analytic.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 # Copyright 2018 Magnus ((www.magnus.nl).)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -502,3 +503,16 @@ class AccountAnalyticLine(models.Model):
         ))
         self.env.cr.execute(list_query, where_clause_params)
         return True
+
+    @api.multi
+    def modified(self, fnames):
+        if not self.env.context.get('_timesheet_write'):
+            # disable modification triggers when writing timesheets
+            return super(AccountAnalyticLine, self).modified(fnames)
+
+    @api.multi
+    def _get_sale_order_line(self, vals=None):
+        if not self.env.context.get('_timesheet_write'):
+            # disable linking sale order lines to analytic lines on timesheets
+            return super(AccountAnalyticLine, self)._get_sale_order_line(vals=vals)
+        return dict(vals or {})


### PR DESCRIPTION
@whulshof this is now production quality, but please still test thoroughly that I don't mess up things here.

One issue will be removing all lines of some project in a timesheet, then the project in question's aggregates will be inaccurate until the next recomputation is triggered, but I consider this an acceptable tradeoff.