### PR TITLE
[FIX] magnus_timesheet: Reduce number of recomputations drastically

### DIFF
--- a/magnus_timesheet/models/hr_timesheet_sheet.py
+++ b/magnus_timesheet/models/hr_timesheet_sheet.py
@@ -380,7 +380,7 @@ class HrTimesheetSheet(models.Model):
         self.generate_km_lines()
         return res
 
-    @job
+    @job(default_channel='root.timesheet')
     def _recompute_timesheet(self, fields):
         """Recompute this sheet and its lines.
         This function is called asynchronically after create/write"""
@@ -392,14 +392,14 @@ class HrTimesheetSheet(models.Model):
                 self.env['account.analytic.line']._fields.keys()
             )
         self.recompute()
-        # TODO: emit a bus message to update __last_update on clients
 
     def _queue_recompute_timesheet(self, fields):
         """Queue a recomputation if appropriate"""
         if not fields or not self:
             return
         return self.with_delay(
-            identity_key=self._name + ',' + ','.join(map(str, self.ids))
+            identity_key=self._name + ',' + ','.join(map(str, self.ids)) +
+            ',' + ','.join(fields)
         )._recompute_timesheet(fields)
 
     @api.model


### PR DESCRIPTION
this is a PoC for better queue handling. You'll see the fields changed as parameters for the recomputation in the job list, and there should never be more than one recomputation for the same field(s) and id(s).

I left out overriding https://github.com/OCA/OCB/blob/10.0/odoo/models.py#L3250 for the time being as we discussed.